### PR TITLE
added font accessors, removed `GFX::swap`

### DIFF
--- a/GFX.cpp
+++ b/GFX.cpp
@@ -191,3 +191,6 @@ void GFX::drawLine(int x_start, int y_start, int x_end, int y_end, colors color)
 void GFX::setFont(const uint8_t* font){
 	this->font = font;
 }
+const uint8_t* GFX::getFont(){
+	return font;
+}

--- a/GFX.cpp
+++ b/GFX.cpp
@@ -1,5 +1,13 @@
 #include "GFX.hpp"
 
+namespace {
+	inline static void swap(int &a, int &b) {
+	    int tmp = a;
+	    a = b;
+	    b = tmp;
+	}
+};
+
 /**
  * Create GFX instantion 
  *
@@ -180,9 +188,6 @@ void GFX::drawLine(int x_start, int y_start, int x_end, int y_end, colors color)
 	}
 }
 
-
-inline void GFX::swap(int &a, int &b) {
-    int tmp = a;
-    a = b;
-    b = tmp;
+void GFX::setFont(const uint8_t* font){
+	this->font = font;
 }

--- a/GFX.cpp
+++ b/GFX.cpp
@@ -158,13 +158,13 @@ void GFX::drawLine(int x_start, int y_start, int x_end, int y_end, colors color)
 	int16_t steep = abs(y_end - y_start) > abs(x_end - x_start);
 
 	if (steep) {
-		this->swap(x_start, y_start);
-		this->swap(x_end, y_end);
+		swap(x_start, y_start);
+		swap(x_end, y_end);
 	}
 
 	if (x_start > x_end) {
-		this->swap(x_start, x_end);
-		this->swap(y_start, y_end);
+		swap(x_start, x_end);
+		swap(y_start, y_end);
 	}
 
 	int16_t dx = x_end - x_start;

--- a/GFX.hpp
+++ b/GFX.hpp
@@ -13,8 +13,6 @@
 class GFX : public SSD1306 {
     const uint8_t* font = font_8x5;
 
-    static void swap(int &a, int &b);
-
     public:
         GFX(uint16_t const DevAddr, size Size, i2c_inst_t * i2c);
 
@@ -27,6 +25,7 @@ class GFX : public SSD1306 {
         void drawVerticalLine(int x, int y, int w, colors color = colors::WHITE);
         void drawLine(int x_start, int y_start, int x_end, int y_end, colors color = colors::WHITE);
 
+        void setFont(const uint8_t* font);
 };
 
 #endif

--- a/GFX.hpp
+++ b/GFX.hpp
@@ -26,6 +26,7 @@ class GFX : public SSD1306 {
         void drawLine(int x_start, int y_start, int x_end, int y_end, colors color = colors::WHITE);
 
         void setFont(const uint8_t* font);
+        const uint8_t* getFont();
 };
 
 #endif


### PR DESCRIPTION
* this allows to set/get the font, closing #3
* also, i removed `swap` from `GFX` and made it static and anonymous-namespaced. it was `private: inline` anyway, so literally no way for anything outside of `GFX` to access it, but it still cluttered the class and exports, so now the compiler knows how to optimize it correctly.